### PR TITLE
changes for the new API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a wrapper for the PatentsView API.
 
-* [PatentsView Glossary](http://www.patentsview.org/api/glossary.html) provides a description of the variables.
+* [PatentsView Glossary](https://patentsview.org/glossary) provides a description of the variables.
 
 ## Similar Projects
 
@@ -10,8 +10,11 @@ This project is a wrapper for the PatentsView API.
 
 ## Important Notes:
 
-* Use <https://dev.patentsview.org> and not <https://www.patentsview.org/>; the former is laxer in terms of accepting input
-* Naming is finicky (more so on the second one), even spacing and other character affect the search results (see below).
+* An API key is required, one can be requested [here](https://patentsview.org/apis/keyrequest).
+* There needs to be an environmental variable PATENTSVIEW_API_KEY set to the value of your API key.
+* The endpoints of the new version of the API are at <https://search.patentsview.org>, they had last been at <https://api.patentsview.org/>.
+* The API team produced a [Swagger UI page](https://search.patentsview.org/swagger-ui/) for the new version of the API. Your API key can be entered by pressing the Authorize button.
+* The new version of the API does not seem to return USPC classifications, the code was switched to use CPC classifications.
 
 ## Remarks about the data
 
@@ -21,15 +24,10 @@ This project is a wrapper for the PatentsView API.
     * As an example: `NETFLIX, INC.` has an `assignee_key_id` of `17594` and an `assignee_id` of `org_2lAuxOpAtNMvtTxhuLmX`; `NETFLIX.COM, INC.` on the other hand an `assignee_key_id` of `org_UNHkzir8tY7NlQrOJKT4` and an `assignee_id` of `363028`. (This of course assumes `NETFLIX, INC.` and `NETFLIX.COM, INC.` are the same company, which is highly probable).
     * The same applies for acquisitions. Example: Company A has patent *X*; once company B acquires company A, patent *X* would still show that it is assigned to company *A*.
     * Probably the same thing holds if a company acquires certain patents of another company.
-* The patents can be assigned to organizations (as opposed to individuals). This is indicated by the 'assignee organization' field returned by the API.
+* The patents can be assigned to organizations (as opposed to individuals). This is indicated by the 'assignees_at_grant.organization' field returned by the API.
 * The assignee organizations (i.e. companies) are distinguished by name. Each organization name is a 'separate' company.
     * This means that a patent can be assigned to "IBM", "IBM Inc.", "International Business Machines".
     * Different organization names have different `assignee_id`s and `assignee_key_id`s (see `NETFLIX` example above).
-* **Different endpoints behave differently**: particularly <https://www.patentsview.org/> and <https://dev.patentsview.org>
-    * **Naming is finicky on the first one**: If you search for `Abbott Laboratories` or for `ABBOTT LABORATORIES`, 
-    you will get the same results. If you search for `ABBOTT Laboratories`, `Abbott LABORATORIES`, 
-    or `abbott laboratories`, you will get nothing.
-    * The second one seems to work better, but you still have to replace the carriage return and line break characters.
 
 ## Adding companies
 
@@ -100,7 +98,7 @@ SELECT
 	an.name as "Company Name Listed on Patent",
 	p.year,
 	p.grant_date as "Grant Date",
-	p.uspc_class as "USPC Classes"
+	p.cpc_subsection_id as "CPC Subsections"
 FROM 
 	patents as p
 JOIN 


### PR DESCRIPTION
This addresses issue #2 where the API provider is making changes.  

One of the API team's changes removed the citation data from the patents endpoint.  We now need to call a new patent_classification endpoint instead.  They also changed some attribute names, removed some attributes and are requiring nested fields to be fully qualified.  Ex it's now assignees_at_grant.name_last instead of assignee_last_name.   The organization name also changed from a string to a full text field meaning we have to use _text_phrase instead of _eq as the search criteria.  

One tip that could be added somewhere for developers is that the new [Swagger UI object](https://search.patentsview.org/static/openapi.json) can be imported into Postman to create a nicely loaded collection for the new version of the API (import the url into Postman or save the file locally and then import into Postman).

Other major changes are mentioned in the README.md and are copied here

## Important Notes:

* An API key is required, one can be requested [here](https://patentsview.org/apis/keyrequest).
* There needs to be an environmental variable PATENTSVIEW_API_KEY set to the value of your API key.
* The endpoints of the new version of the API are at <https://search.patentsview.org>, they had last been at <https://api.patentsview.org/>.
* The API team produced a [Swagger UI page](https://search.patentsview.org/swagger-ui/) for the new version of the API. Your API key can be entered by pressing the Authorize button.
* The new version of the API does not seem to return USPC classifications, the code was switched to use CPC classifications.
